### PR TITLE
Install the developement depedencies before building Etherpad lite to be able to build the admin UI, listen to notifications for handlers

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,6 +10,8 @@
     PATH: "{{ etherpad_environment_path }}"
   check_mode: false
   changed_when: true
+  become: true
+  become_user: "{{ etherpad_user }}"
   listen: "Build etherpad-lite"
 
 - name: Build etherpad-lite with respect to the node environment

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: Install the dev depedecencies
   ansible.builtin.shell: |
     pnpm i
+    pnpm run build:etherpad
   args:
     executable: /bin/bash
     chdir: "{{ etherpad_path }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,18 @@
 ---
-- name: Build etherpad-lite
+- name: Install the dev depedecencies
+  ansible.builtin.shell: |
+    pnpm i
+  args:
+    executable: /bin/bash
+    chdir: "{{ etherpad_path }}"
+  environment:
+    NODE_ENV: "developement"
+    PATH: "{{ etherpad_environment_path }}"
+  check_mode: false
+  changed_when: true
+  listen: "Build etherpad-lite"
+
+- name: Build etherpad-lite with respect to the node environment
   ansible.builtin.shell: |
     pnpm i
     pnpm run build:etherpad
@@ -9,10 +22,11 @@
   environment:
     NODE_ENV: "{{ etherpad_node_environment }}"
     PATH: "{{ etherpad_environment_path }}"
-  become: true
-  become_user: "{{ etherpad_user }}"
   check_mode: false
   changed_when: true
+  become: true
+  become_user: "{{ etherpad_user }}"
+  listen: "Build etherpad-lite"
   notify: Restart etherpad-lite
 
 - name: Restart etherpad-lite

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,9 +39,10 @@
     version: "{{ etherpad_repository_version }}"
     key_file: "{{ etherpad_repository_key_file }}"
     depth: 1
+    force: false
   become: true
   become_user: "{{ etherpad_user }}"
-  notify: Build etherpad-lite
+  notify: "Build etherpad-lite"
 
 - name: Copy configuration file
   ansible.builtin.template:


### PR DESCRIPTION
Hello,

This pull request introduces two changes ; 

1. We are now installing the development dependencies, regardless of the NODE_ENV, because following the issue at https://github.com/ether/etherpad-lite/issues/7040 , we need them to build the admin UI, even if we are in a production environment. 
2. To be able to do this *and* build Etherpad-lite when the cloning of the git repository has changed files, we are now using the [listen](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html#naming-handlers) keyword to be able to run two handlers.
2.1 We've also clarified that the cloning of the git repository is not forced, which was the case before. 

This pull request complements https://github.com/systemli/ansible-role-etherpad/pull/108