### PR TITLE
Update toolchain for Etherpad 3.x support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .molecule
 .tox
 molecule/*/.molecule
+.ansible/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Role to install, configure & maintain Etherpad Lite. You can use this role to configure Etherpad with those storage solutions : MySQL (or MariaDB), Redis and PostgreSQL.
 
+## Requirements
+
+This role tracks the Etherpad 3.x release series (tested against Etherpad `3.2.0`). Etherpad 3.x requires **Node.js >= 24.0.0** and **pnpm >= 11.1.2** on the target host. Make sure a matching Node.js (e.g. via `geerlingguy.nodejs`) and `pnpm` are installed before running this role.
+
 Currently only MySQL allows to create the user and database. For PostgreSQL those operations should be done by your own (If you want or need to automate those tasks, you can probably use this role : geerlingguy.postgresql).
 
 This playbook also allows to install some plugins for Etherpad :

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,6 +5,6 @@
   roles:
     - role: ansible-role-etherpad
   vars:
-    etherpad_repository_version: 2.2.7
+    etherpad_repository_version: 3.2.0
     etherpad_api_key: "secure_api_key"
     etherpad_abiword_enabled: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,7 +15,7 @@
       ansible.builtin.include_role:
         name: geerlingguy.nodejs
       vars:
-        nodejs_version: 22.x
+        nodejs_version: 24.x
         nodejs_install_npm_user: "root"
         nodejs_npm_global_packages:
           - name: pnpm

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - community.general
-  - community.mysql
+  - ansible.mysql

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: Create mysql database
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ etherpad_mysql_database_name }}"
     collation: "{{ etherpad_mysql_database_collation }}"
     state: present
@@ -20,7 +20,7 @@
   when: database is changed
 
 - name: Import mysqldb schema # noqa no-handler
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ etherpad_mysql_database_name }}"
     collation: "{{ etherpad_mysql_database_collation }}"
     state: import
@@ -40,7 +40,7 @@
   when: etherpad_mysql_database_password is undefined or etherpad_mysql_database_password | length == 0
 
 - name: Create mysql user
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ etherpad_mysql_database_user }}"
     state: present
     password: "{{ etherpad_mysql_database_password }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-etherpad_min_node_version: "18.18.2"
+etherpad_min_node_version: "24.0.0"


### PR DESCRIPTION
## Summary

Etherpad released the 3.x series (latest `3.2.0`), which requires **Node.js >= 24.0.0** and **pnpm >= 11.1.2**. The role still allowed Node 18/22 and was tested against Etherpad `2.2.7`, so a fresh install against a current Etherpad checkout would fail the Node preflight check or the `pnpm build` step.

This is the foundational change of a larger, batched effort to bring the role up to date with Etherpad 3.x. It focuses on the toolchain and the tested version so that install & build are verified to work before configuration options are extended in follow-up PRs.

## What was done

- Raise `etherpad_min_node_version` to `24.0.0` (`vars/main.yml`), matching Etherpad 3.x's `engines` requirement.
- Bump the Node.js version in the molecule test environment to `24.x` (`molecule/default/prepare.yml`).
- Pin the Etherpad version under test to `3.2.0` (`molecule/default/converge.yml`).
- Document the Node.js / pnpm runtime requirements and the targeted Etherpad release series in the README.
- Use the canonical `ansible.mysql` FQCN for the MySQL modules so the `ansible-lint` `production` profile passes (`community.mysql` now redirects there).

The existing preflight checks already validate the installed Node version against `etherpad_min_node_version` and the presence of `pnpm`, so no task logic changes were needed.

---
<sub>The changes and the PR were generated by Claude.</sub>