### PR TITLE
Remove abiword document conversion support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,7 +77,6 @@ etherpad_require_session: "false"
 etherpad_edit_only: "false"
 etherpad_minify: "true"
 etherpad_max_age: 21600
-etherpad_abiword: "{{ '/usr/bin/abiword' if etherpad_abiword_enabled else 'null' }}"
 etherpad_soffice: "{{ '/usr/bin/soffice' if etherpad_soffice_enabled else 'null' }}"
 etherpad_allow_unknown_file_ends: "true"
 etherpad_require_authentication: "false"
@@ -129,7 +128,6 @@ etherpad_toolbar:
     - ["timeslider_export", "timeslider_returnToPad"]
 etherpad_log_level: "INFO"
 etherpad_log_layout_type: "colored"
-etherpad_abiword_enabled: false
 etherpad_soffice_enabled: false
 
 etherpad_redis_host: localhost

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,4 +7,3 @@
   vars:
     etherpad_repository_version: 3.2.0
     etherpad_api_key: "secure_api_key"
-    etherpad_abiword_enabled: true

--- a/tasks/abiword.yml
+++ b/tasks/abiword.yml
@@ -1,5 +1,0 @@
----
-- name: Ensure abiword package is installed
-  ansible.builtin.apt:
-    pkg: abiword
-    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,10 +85,6 @@
     mode: "0644"
   when: etherpad_custom_logo_src is defined
 
-- name: Import abiword tasks
-  ansible.builtin.import_tasks: abiword.yml
-  when: etherpad_abiword_enabled
-
 - name: Import soffice tasks
   ansible.builtin.import_tasks: soffice.yml
   when: etherpad_soffice_enabled

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -100,7 +100,6 @@
   "editOnly": {{ etherpad_edit_only }},
   "minify": {{ etherpad_minify }},
   "maxAge": {{ etherpad_max_age }},
-  "abiword": {{ etherpad_abiword | to_json }},
   "soffice": {{ etherpad_soffice | to_json }},
   "allowUnknownFileEnds": {{ etherpad_allow_unknown_file_ends }},
   "requireAuthentication": {{ etherpad_require_authentication }},


### PR DESCRIPTION
## Summary

Etherpad 3.x removed AbiWord support entirely. The `abiword` key no longer exists in Etherpad's `settings.json.template`, and document conversion now relies solely on LibreOffice (`soffice`). The role still shipped an `abiword` task and rendered an `abiword` key, which only produced dead configuration that current Etherpad ignores.

This removes the abiword task, its include, the rendered settings key and the related variables. LibreOffice/`soffice` support is unaffected.

> Stacked on top of #131. Review/merge that one first.

---
<sub>The changes and the PR were generated by Claude.</sub>