### PR TITLE
Add ipLogging setting for Etherpad 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Those variables allow to configure Etherpad with PostgreSQL. To be able to use t
     etherpad_headerauth_displayname_header: x-authenticated-name
 Configuration values for the [ep_headerauth](https://www.npmjs.com/package/ep_headerauth) plugin (authentication with http header). If you want to use this plugin, `etherpad_trust_proxy` and `etherpad_require_authentication` must be set to True.
 
+    etherpad_ip_logging: "anonymous"
+Controls how client IP addresses are logged in Etherpad 3.x. Valid values are `anonymous`, `truncated` and `full`. This setting supersedes the deprecated `etherpad_disable_ip_logging` (which is still rendered for backwards compatibility, but `ipLogging` takes precedence).
+
 For more information about available variables (and their default values) : see `defaults/main.yml`
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,9 @@ etherpad_users: []
 #    is_admin: "true"
 etherpad_api_key: ""
 etherpad_session_key: "Y7sc5qSXw5aEBIDGsjfkyLJDV"
+# IP logging granularity for Etherpad 3.x: "anonymous", "truncated" or "full".
+# Takes precedence over the deprecated etherpad_disable_ip_logging.
+etherpad_ip_logging: "anonymous"
 etherpad_disable_ip_logging: "true"
 etherpad_default_text: "Welcome to Etherpad!\\n\\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\\n\\nGet involved with Etherpad at http:\\/\\/etherpad.org\\n"
 etherpad_pad_options_no_colors: "false"

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -111,6 +111,7 @@
     "sessionLifetime": {{ etherpad_cookie_session_lifetime }},
     "sessionRefreshInterval": {{ etherpad_cookie_session_refresh_interval }}
   },
+  "ipLogging": "{{ etherpad_ip_logging }}",
   "disableIPlogging": {{ etherpad_disable_ip_logging }},
   "automaticReconnectionTimeout": {{ etherpad_automatic_reconnection_timeout }},
   "scrollWhenFocusLineIsOutOfViewport": {


### PR DESCRIPTION
## Summary

Etherpad 3.x replaces the boolean `disableIPlogging` with a more granular `ipLogging` option that accepts `anonymous`, `truncated` or `full`. `disableIPlogging` is now deprecated upstream but still accepted.

This adds the `etherpad_ip_logging` variable (default `anonymous`) and renders the `ipLogging` key, while keeping `disableIPlogging` for backwards compatibility. When both are present, `ipLogging` takes precedence.

> Stacked on top of #132.

---
<sub>The changes and the PR were generated by Claude.</sub>