### PR TITLE
Add Etherpad 3.x updates configuration block

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,15 @@ etherpad_ip: 0.0.0.0
 etherpad_port: 9001
 etherpad_show_settings_in_admin_page: "true"
 etherpad_enable_metrics: "true"
+# Etherpad 3.x built-in updater. Defaults to "off" because this role manages
+# the Etherpad version via git/Ansible; a self-updater would conflict with the
+# checked-out revision. Set to "notify", "manual", "auto" or "autonomous" if
+# you want Etherpad to manage its own updates instead.
+etherpad_updates_tier: "off"
+etherpad_updates_source: "github"
+etherpad_updates_channel: "stable"
+etherpad_updates_install_method: "auto"
+etherpad_updates_check_interval_hours: 6
 etherpad_cleanup:
   enabled: "false"
   keepRevisions: 5

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -11,6 +11,13 @@
   "port" : {{ etherpad_port }},
   "showSettingsInAdminPage": {{ etherpad_show_settings_in_admin_page }},
   "enableMetrics": {{ etherpad_enable_metrics }},
+  "updates": {
+    "tier": "{{ etherpad_updates_tier }}",
+    "source": "{{ etherpad_updates_source }}",
+    "channel": "{{ etherpad_updates_channel }}",
+    "installMethod": "{{ etherpad_updates_install_method }}",
+    "checkIntervalHours": {{ etherpad_updates_check_interval_hours }}
+  },
   "cleanup": {{ etherpad_cleanup | to_nice_json }},
   "sessionKey": "{{ etherpad_session_key }}",
 {% if etherpad_ssl_enabled %}


### PR DESCRIPTION
## Summary

Etherpad 3.x ships a built-in updater configured through the `updates` key. This adds the block with a conservative default tier of `off`, because this role manages the Etherpad version through git/Ansible and a self-updater would conflict with the checked-out revision.

Operators who prefer Etherpad-managed updates can opt into `notify`, `manual`, `auto` or `autonomous` via `etherpad_updates_tier`.

> Stacked on top of #134.

---
<sub>The changes and the PR were generated by Claude.</sub>