### PR TITLE
Add Etherpad 3.x admin, mail, GDPR and privacy banner options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,25 @@ etherpad_updates_source: "github"
 etherpad_updates_channel: "stable"
 etherpad_updates_install_method: "auto"
 etherpad_updates_check_interval_hours: 6
+# Admin OpenAPI document at /admin/openapi.json
+etherpad_admin_openapi_enabled: "false"
+# Contact email for admin notifications (null to disable)
+etherpad_admin_email: null
+# Outbound SMTP for notifications. host null = log-only (no mail sent).
+# etherpad_mail_auth expects null or a mapping, e.g. {"user": "...", "pass": "..."}
+etherpad_mail_host: null
+etherpad_mail_port: 587
+etherpad_mail_secure: "false"
+etherpad_mail_from: null
+etherpad_mail_auth: null
+# GDPR Art. 17 author erasure REST endpoint
+etherpad_gdpr_author_erasure_enabled: "false"
+# Privacy banner shown on pad load
+etherpad_privacy_banner_enabled: "false"
+etherpad_privacy_banner_title: ""
+etherpad_privacy_banner_body: ""
+etherpad_privacy_banner_learn_more_url: null
+etherpad_privacy_banner_dismissal: "dismissible"
 etherpad_cleanup:
   enabled: "false"
   keepRevisions: 5

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -18,7 +18,21 @@
     "installMethod": "{{ etherpad_updates_install_method }}",
     "checkIntervalHours": {{ etherpad_updates_check_interval_hours }}
   },
+  "adminOpenAPI": {
+    "enabled": {{ etherpad_admin_openapi_enabled }}
+  },
+  "adminEmail": {{ etherpad_admin_email | to_json }},
+  "mail": {
+    "host": {{ etherpad_mail_host | to_json }},
+    "port": {{ etherpad_mail_port }},
+    "secure": {{ etherpad_mail_secure }},
+    "from": {{ etherpad_mail_from | to_json }},
+    "auth": {{ etherpad_mail_auth | to_json }}
+  },
   "cleanup": {{ etherpad_cleanup | to_nice_json }},
+  "gdprAuthorErasure": {
+    "enabled": {{ etherpad_gdpr_author_erasure_enabled }}
+  },
   "sessionKey": "{{ etherpad_session_key }}",
 {% if etherpad_ssl_enabled %}
   "ssl" : {
@@ -112,6 +126,13 @@
   "privacy": {
     "updateCheck": {{ etherpad_privacy_update_check }},
     "pluginCatalog": {{ etherpad_privacy_plugin_catalog }}
+  },
+  "privacyBanner": {
+    "enabled": {{ etherpad_privacy_banner_enabled }},
+    "title": {{ etherpad_privacy_banner_title | to_json }},
+    "body": {{ etherpad_privacy_banner_body | to_json }},
+    "learnMoreUrl": {{ etherpad_privacy_banner_learn_more_url | to_json }},
+    "dismissal": "{{ etherpad_privacy_banner_dismissal }}"
   },
   "suppressErrorsInPadText": {{ etherpad_suppress_errors_in_pad_text }},
   "requireSession": {{ etherpad_require_session }},


### PR DESCRIPTION
## Summary

Completes the `settings.json` coverage for Etherpad 3.x by adding the remaining new top-level blocks:

- `adminOpenAPI.enabled` and `adminEmail`
- `mail.{host,port,secure,from,auth}` for outbound SMTP notifications
- `gdprAuthorErasure.enabled` (Art. 17 author erasure endpoint)
- `privacyBanner.{enabled,title,body,learnMoreUrl,dismissal}`

Nullable and structured values (`adminEmail`, `mail.host`/`from`/`auth`, banner texts and `learnMoreUrl`) are rendered via `to_json` so they become proper JSON `null`, strings or objects. All blocks default to a disabled/log-only state, so existing renders are unchanged unless explicitly configured.

> Stacked on top of #135. Final PR of the Etherpad 3.x update series.

---
<sub>The changes and the PR were generated by Claude.</sub>