### PR TITLE
Use canonical ansible.mysql FQCN for MySQL modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .molecule
 .tox
 molecule/*/.molecule
+.ansible/

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - community.general
-  - community.mysql
+  - ansible.mysql

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -5,7 +5,7 @@
     state: present
 
 - name: Create mysql database
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ etherpad_mysql_database_name }}"
     collation: "{{ etherpad_mysql_database_collation }}"
     state: present
@@ -20,7 +20,7 @@
   when: database is changed
 
 - name: Import mysqldb schema # noqa no-handler
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     name: "{{ etherpad_mysql_database_name }}"
     collation: "{{ etherpad_mysql_database_collation }}"
     state: import
@@ -40,7 +40,7 @@
   when: etherpad_mysql_database_password is undefined or etherpad_mysql_database_password | length == 0
 
 - name: Create mysql user
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     name: "{{ etherpad_mysql_database_user }}"
     state: present
     password: "{{ etherpad_mysql_database_password }}"


### PR DESCRIPTION
## Summary

The CI lint job fails on three `fqcn[canonical]` violations under ansible-lint's `production` profile:

```
fqcn[canonical]: You should use canonical module name `ansible.mysql.mysql_db` instead of `community.mysql.mysql_db`.
fqcn[canonical]: You should use canonical module name `ansible.mysql.mysql_user` instead of `community.mysql.mysql_user`.
```

The `community.mysql` collection has migrated to `ansible.mysql`, and recent `community.mysql` releases redirect `mysql_db` and `mysql_user` to their `ansible.mysql` canonical names. ansible-lint resolves those redirects and expects the canonical names.

## What was done

- Switch the MySQL tasks in `tasks/mysql.yml` to `ansible.mysql.mysql_db` / `ansible.mysql.mysql_user`.
- Point `requirements.yml` at `ansible.mysql`.
- Ignore the local `.ansible/` working directory that ansible tooling creates.

## Note

`ansible-lint` still emits a non-fatal warning about the custom `.yamllint` config being stricter/looser than its expectations. It does not fail the run and is left unchanged here to keep this fix focused on the lint failures.

---
<sub>The changes and the PR were generated by Claude.</sub>