### PR TITLE
fix: set CI=true for pnpm build to avoid no-TTY abort

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,6 +9,7 @@
   environment:
     NODE_ENV: "{{ etherpad_node_environment }}"
     PATH: "{{ etherpad_environment_path }}"
+    CI: "true"
   become: true
   become_user: "{{ etherpad_user }}"
   check_mode: false


### PR DESCRIPTION
## Summary

The `Build etherpad-lite` handler ran `pnpm i` without a TTY during the Ansible run. With pnpm 11, when pnpm wants to purge the `node_modules` directory it asks for interactive confirmation; without a TTY it aborts instead with:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
```

This failed the build handler. As a follow-on symptom, Etherpad then logged `Cannot create the admin UI in production mode` at runtime, because in `production` mode it expects pre-built admin UI artifacts that the failed build never produced.

## Why

Setting `CI=true` makes pnpm run non-interactively, which matches the non-interactive nature of an Ansible run and lets `pnpm i` / `build:etherpad` complete successfully.

---
<sub>The changes and the PR were generated by Claude.</sub>